### PR TITLE
Enable `explicitApi` and `allWarningsAsErrors`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,9 @@ repositories {
 }
 
 kotlin {
+    explicitApi()
     compilerOptions {
+        allWarningsAsErrors = true
         freeCompilerArgs.add("-Xcontext-receivers")
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.kotlin.dsl.allWarningsAsErrors=true

--- a/src/main/kotlin/KordExtension.kt
+++ b/src/main/kotlin/KordExtension.kt
@@ -5,34 +5,33 @@ import org.gradle.api.provider.Property
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.getByName
 import org.jetbrains.kotlin.konan.target.Family
-import org.jetbrains.kotlin.konan.target.KonanTarget
 
-interface KordExtension {
+public interface KordExtension {
     /**
      * The host used to build "common targets" (JVM & JS).
      *
-     * Defaults to [KonanTarget.LINUX_X64]
+     * Defaults to [Family.LINUX]
      */
-    val commonHost: Property<Family>
+    public val commonHost: Property<Family>
 
     /**
      * The name of the publication to publish.
      *
      * Defaults to `maven`
      */
-    val publicationName: Property<String>
+    public val publicationName: Property<String>
 
     /**
      * The main development branch of the projects.
      *
      * Defaults to `main`
      */
-    val mainBranchName: Property<String>
+    public val mainBranchName: Property<String>
 
     /**
      * Host to use for metadata publication.
      */
-    val metadataHost: Property<Family>
+    public val metadataHost: Property<Family>
 }
 
 internal fun ExtensionAware.createKordExtension() = extensions.create<KordExtension>("kord").apply {

--- a/src/main/kotlin/KordGradlePlugin.kt
+++ b/src/main/kotlin/KordGradlePlugin.kt
@@ -3,9 +3,8 @@ package dev.kord.gradle.tools
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-@Suppress("unused") // see build.gradle.kts
-class KordGradlePlugin : Plugin<Project> {
-    override fun apply(target: Project) = with(target) {
+public class KordGradlePlugin : Plugin<Project> {
+    override fun apply(target: Project): Unit = with(target) {
         createKordExtension()
         applyVersioning()
         if (plugins.hasPlugin("org.jetbrains.kotlin.multiplatform")) {

--- a/src/main/kotlin/MultiplatformHelpers.kt
+++ b/src/main/kotlin/MultiplatformHelpers.kt
@@ -35,7 +35,7 @@ internal fun Project.applyMultiplatformHelpers() {
 
             val commonHost = kordExtension.commonHost.get()
             val metadataHost = kordExtension.metadataHost.get()
-            umbrellaTask(commonHost, "Publishes all publications designated to this hosts OS") {
+            umbrellaTask(commonHost, "Publishes all publications designated to this host's OS") {
                 if (metadataHost.isCurrent()) {
                     val publicationName = kordExtension.publicationName.get().replaceFirstChar { it.uppercaseChar() }
                     dependOnSafe("publishKotlinMultiplatformPublicationTo${publicationName}Repository")

--- a/src/main/kotlin/Versioning.kt
+++ b/src/main/kotlin/Versioning.kt
@@ -4,6 +4,10 @@ import dev.kord.gradle.tools.util.libraryVersion
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
 
+/**
+ * This uses [Project.afterEvaluate] to account for changes to [KordExtension.mainBranchName] which is used by
+ * [libraryVersion].
+ */
 internal fun Project.applyVersioning() = afterEvaluate {
     version = libraryVersion
 }
@@ -11,5 +15,5 @@ internal fun Project.applyVersioning() = afterEvaluate {
 /**
  * Lazy accessor of the Project version.
  */
-val Project.lazyVersion: Provider<String>
+public val Project.lazyVersion: Provider<String>
     get() = provider { version.toString() }

--- a/src/main/kotlin/util/Project.kt
+++ b/src/main/kotlin/util/Project.kt
@@ -9,7 +9,7 @@ private val Project.tag
         ?.lines()
         ?.single()
 
-val Project.libraryVersion
+public val Project.libraryVersion: String
     get() = tag ?: run {
         val prBranch = System.getenv("PR_BRANCH")?.ifBlank { null }
         val envBranch = prBranch ?: System.getenv("GIT_BRANCH")?.substringAfter("refs/heads/")
@@ -22,7 +22,7 @@ val Project.libraryVersion
         "$snapshotPrefix-SNAPSHOT"
     }.also { logger.lifecycle("Version set to: $it") }
 
-val Project.commitHash get() = git("rev-parse", "--verify", "HEAD")
-val Project.shortCommitHash get() = git("rev-parse", "--short", "HEAD")
+public val Project.commitHash: String get() = git("rev-parse", "--verify", "HEAD")
+public val Project.shortCommitHash: String get() = git("rev-parse", "--short", "HEAD")
 
-val Project.isRelease get() = tag != null
+public val Project.isRelease: Boolean get() = tag != null


### PR DESCRIPTION
`explicitApi` will prevent accidentally having `public` declarations and `allWarningsAsErrors` will force us to deal with warnings, so they won't stick around forever.